### PR TITLE
Make interval end messages optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ end_interval("end my task")
 
 Both the `begin_interval` method and the callback take a message.
 Instruments.app includes these messages in the visualization and allows you to
-categorize intervals by their messages.
+categorize intervals by their messages. When no message is specified for the
+interval end, the same message as the begin will be used.
 
 You can also use the `Signposter.use_interval` context manager in place of the
 callback approach:
@@ -70,7 +71,8 @@ with signposter.use_interval("begin my task", "end my task"):
     # The task for which you want to measure the duration.
 ```
 
-`use_interval` takes the begin and end messages as its arguments.
+`use_interval` takes the begin and end messages as its arguments. The end
+message is also optional for the context manager.
 
 ### Emitting an event
 

--- a/os_signpost/tests/test_signposter.py
+++ b/os_signpost/tests/test_signposter.py
@@ -17,6 +17,11 @@ def test_context_manager(signposter):
     ):
         ()
 
+    with signposter.use_interval(
+        "test_context_manager"
+    ):
+        ()
+
 
 def test_emit_event(signposter):
     signposter.emit_event("test_emit_event")
@@ -25,3 +30,6 @@ def test_emit_event(signposter):
 def test_interval(signposter):
     end_interval = signposter.begin_interval("end test_interval")
     end_interval("end test_interval")
+
+    end_interval = signposter.begin_interval("end test_interval")
+    end_interval()


### PR DESCRIPTION
Use the begin message when no end message is provided.
